### PR TITLE
CLOSES #1 - Update Fess to 11.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Use this Vagrantfile and CloudInit configuration to install Fess, Elasticsearch 
 
 ### Prerequisites
 
-- [VirtualBox](https://www.virtualbox.org) (5.1.14)
-- [Vagrant](https://www.vagrantup.com) (1.9.1)
+- [VirtualBox](https://www.virtualbox.org) (5.1.16)
+- [Vagrant](https://www.vagrantup.com) (1.9.2)
 
 ### Installation
 

--- a/user-data
+++ b/user-data
@@ -119,7 +119,7 @@ runcmd:
   - [ /usr/share/elasticsearch/bin/elasticsearch-plugin, install, -s, --batch, "org.codelibs:elasticsearch-dataformat:5.2.0" ]
   - [ /usr/share/elasticsearch/bin/elasticsearch-plugin, install, -s, --batch, "org.codelibs:elasticsearch-langfield:5.2.0" ]
   - [ systemctl, enable, --force, --now, --no-block, elasticsearch.service ]
-  - [ yum, -y, install, "https://github.com/codelibs/fess/releases/download/fess-11.0.0/fess-11.0.0.rpm" ]
+  - [ yum, -y, install, "https://github.com/codelibs/fess/releases/download/fess-11.0.1/fess-11.0.1.rpm" ]
   - [ systemctl, enable, --force, --now, --no-block, fess.service ]
   - [ firewall-cmd, --zone=public, --permanent, "--add-port=80/tcp", "--add-port=443/tcp" ]
   - [ firewall-cmd, --reload ]

--- a/user-data
+++ b/user-data
@@ -99,7 +99,7 @@ write_files:
 #   - [ /bin/bash, -c, "rpm -q epel-release &> /dev/null || yum -y install epel-release" ]
 packages:
   - chrony
-  - elasticsearch-5.2.0
+  - elasticsearch-5.2.2
   - firewalld
   - haproxy
   - java-1.8.0-openjdk-headless
@@ -112,12 +112,12 @@ runcmd:
   - [ ln, -s, /etc/pki/tls/certs/localhost.crt, /etc/pki/tls/certs/sni/localhost.crt ]
   - [ systemctl, enable, --force, --now, --no-block, haproxy.service ]
   - [ /bin/bash, -c, "echo 'configsync.config_path: /var/lib/elasticsearch/config' >> /etc/elasticsearch/elasticsearch.yml" ]
-  - [ /usr/share/elasticsearch/bin/elasticsearch-plugin, install, -s, --batch, "org.codelibs:elasticsearch-analysis-fess:5.2.0" ]
-  - [ /usr/share/elasticsearch/bin/elasticsearch-plugin, install, -s, --batch, "org.codelibs:elasticsearch-analysis-ja:5.2.0" ]
-  - [ /usr/share/elasticsearch/bin/elasticsearch-plugin, install, -s, --batch, "org.codelibs:elasticsearch-analysis-synonym:5.2.0" ]
+  - [ /usr/share/elasticsearch/bin/elasticsearch-plugin, install, -s, --batch, "org.codelibs:elasticsearch-analysis-fess:5.2.1" ]
+  - [ /usr/share/elasticsearch/bin/elasticsearch-plugin, install, -s, --batch, "org.codelibs:elasticsearch-analysis-ja:5.2.1" ]
+  - [ /usr/share/elasticsearch/bin/elasticsearch-plugin, install, -s, --batch, "org.codelibs:elasticsearch-analysis-synonym:5.2.1" ]
   - [ /usr/share/elasticsearch/bin/elasticsearch-plugin, install, -s, --batch, "org.codelibs:elasticsearch-configsync:5.2.0" ]
-  - [ /usr/share/elasticsearch/bin/elasticsearch-plugin, install, -s, --batch, "org.codelibs:elasticsearch-dataformat:5.2.0" ]
-  - [ /usr/share/elasticsearch/bin/elasticsearch-plugin, install, -s, --batch, "org.codelibs:elasticsearch-langfield:5.2.0" ]
+  - [ /usr/share/elasticsearch/bin/elasticsearch-plugin, install, -s, --batch, "org.codelibs:elasticsearch-dataformat:5.2.1" ]
+  - [ /usr/share/elasticsearch/bin/elasticsearch-plugin, install, -s, --batch, "org.codelibs:elasticsearch-langfield:5.2.1" ]
   - [ systemctl, enable, --force, --now, --no-block, elasticsearch.service ]
   - [ yum, -y, install, "https://github.com/codelibs/fess/releases/download/fess-11.0.1/fess-11.0.1.rpm" ]
   - [ systemctl, enable, --force, --now, --no-block, fess.service ]


### PR DESCRIPTION
Resolves #1 

- Updates Fess to release 11.0.1.
- Updates documented requirements for VirtualBox / Vagrant.
- Updates Elasticsearch to 5.2.2 and updates Fess plugins to 5.2.1 where applicable.